### PR TITLE
Update Data services label to Security & analysis

### DIFF
--- a/responses/00_introduction-issue.md
+++ b/responses/00_introduction-issue.md
@@ -28,8 +28,8 @@ This project is centered around a memory game that will be deployed with GitHub 
 
 
 1. Click the [**Settings**]({{ repoUrl }}/settings) tab in your repository.
-1. Scroll down until you see **Data services**.
-1. Under **Data services**, click the check boxes to enable all the data services.
+1. Scroll down until you see **Security & analysis** in the navigation side bar.
+1. Under **Security & analysis**, click the check boxes to enable all the data services.
 2. Scroll down to **GitHub Pages** and set your [default branch as the source](https://docs.github.com/en/github/working-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site), usually `main`.
 
 {% else %}


### PR DESCRIPTION
It's intended to reflect the latest GUI label in the menu for avoiding potential confusion (change it from "Data services" to "Security & analysis").

The change is the same as the following PR in the similar course (except for the capitalization of "analysis" part. It's aligned with the actual label).

https://github.com/githubtraining/security/pull/146